### PR TITLE
augment projectNamespace to return namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ Example
 -------
 
 ```javascript
-var uwp = require('uwp');
-uwp.projectNamespace("Windows");
+const uwp = require('uwp');
+const Windows = uwp.projectNamespace('Windows');
 
 Windows.Storage.KnownFolders.documentsLibrary.createFileAsync(
-  "sample.dat", Windows.Storage.CreationCollisionOption.replaceExisting)
+  'sample.dat', Windows.Storage.CreationCollisionOption.replaceExisting)
   .done(
     function (file) {
-      console.log("ok");
+      console.log('ok');
       uwp.close(); // all async operations are completed, release uwp
     },
     function (error) {
-      console.error("error", error);
+      console.error('error', error);
       uwp.close(); // all async operations are completed, release uwp
     }
 );
@@ -30,7 +30,7 @@ Installation
 
 ### Prerequisites
 
- * Windows 10 [November update](http://windows.microsoft.com/en-us/windows-10/windows-update-faq)
+ * Windows 10 [1511 or above](http://windows.microsoft.com/en-us/windows-10/windows-update-faq)
  * [Visual Studio](https://www.visualstudio.com/vs-2015-product-editions)
  * [Node.js (Chakra)](http://aka.ms/node-chakra-installer)
 

--- a/index.js
+++ b/index.js
@@ -18,10 +18,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-module.exports = require('./build/release/uwp.node');
+const uwp = module.exports = require('./build/release/uwp.node');
 
-// Temporary workaround of chakra requiring window.setTimeout when posting
-// errors during async completion
-global.window = {
-  setTimeout: setTimeout
+const nativeProjectNamespace = uwp.projectNamespace;
+uwp.projectNamespace = function(namespace) {
+  nativeProjectNamespace.call(uwp, namespace);
+  return namespace.split('.').reduce(function(prev, name) {
+    return prev[name];
+  }, global);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -18,18 +18,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-var uwp = require('../index.js');
-uwp.projectNamespace("Windows");
+const uwp = require('../index.js');
+const Windows = uwp.projectNamespace('Windows');
 
 Windows.Storage.KnownFolders.documentsLibrary.createFileAsync(
-  "sample.dat", Windows.Storage.CreationCollisionOption.replaceExisting)
+  'sample.dat', Windows.Storage.CreationCollisionOption.replaceExisting)
   .done(
     function (file) {
-      console.log("ok");
-      uwp.close();
+      console.log('ok');
+      uwp.close(); // all async operations are completed, release uwp
     },
     function (error) {
-      console.error("error", error);
-      uwp.close();
+      console.error('error', error);
+      uwp.close(); // all async operations are completed, release uwp
     }
 );


### PR DESCRIPTION
Augment `projectNamespace` to return (inner) namespace object. This
enables users to write code like:

```
var Windows = uwp.projectNamespace('Windows');
var Gpio = uwp.projectNamespace('Windows.Devices.Gpio');
var gpioController = Gpio.GpioController.getDefault();
```
